### PR TITLE
refine kafka producer

### DIFF
--- a/kafka-adapter/httpapi.go
+++ b/kafka-adapter/httpapi.go
@@ -64,7 +64,7 @@ func (r *Run) AlertMsgFromWebhook(w http.ResponseWriter, hr *http.Request) {
 	log.Infof("alert data %+v", alertData)
 
 	r.AlertMsgs <- alertData
-	r.Rdr.Text(w, http.StatusAccepted, "")
+	r.Rdr.Text(w, http.StatusAccepted, "success")
 }
 
 // CreateRouter creates router

--- a/kafka-adapter/kafka.go
+++ b/kafka-adapter/kafka.go
@@ -2,16 +2,18 @@ package main
 
 import (
 	"encoding/json"
-	"strings"
 	"time"
 
 	"github.com/Shopify/sarama"
+	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/unrolled/render"
 )
 
 const (
-	timeFormat = "2006-01-02 15:04:05"
+	timeFormat    = "2006-01-02 15:04:05"
+	maxRetry      = 12
+	retryInterval = 5 * time.Second
 )
 
 //KafkaMsg represents kafka message
@@ -43,14 +45,25 @@ func getValue(kv KV, key string) string {
 }
 
 //CreateKafkaProducer creates a new SyncProducer using the given broker addresses and configuration
-func (r *Run) CreateKafkaProducer() error {
-	config := sarama.NewConfig()
-	config.Producer.RequiredAcks = sarama.WaitForLocal
-	config.Producer.Return.Successes = true
-	config.Producer.Partitioner = sarama.NewManualPartitioner
+func (r *Run) CreateKafkaProducer(addrs []string) error {
 	var err error
-	r.KafkaClient, err = sarama.NewSyncProducer(strings.Split(*kafkaAddress, ","), config)
-	return err
+
+	for i := 0; i < maxRetry; i++ {
+		config := sarama.NewConfig()
+		config.Producer.Return.Successes = true
+		config.Producer.RequiredAcks = sarama.WaitForLocal
+
+		r.KafkaClient, err = sarama.NewSyncProducer(addrs, config)
+
+		if err != nil {
+			log.Errorf("create kafka producer with error: %v", err)
+			time.Sleep(retryInterval)
+			continue
+		}
+		return nil
+	}
+
+	return errors.Trace(err)
 }
 
 //PushKafkaMsg pushes message to kafka cluster
@@ -59,9 +72,13 @@ func (r *Run) PushKafkaMsg(msg string) error {
 		Topic: *kafkaTopic,
 		Value: sarama.StringEncoder(msg),
 	}
-	log.Infof("sending message %s to kafka", msg)
-	_, _, err := r.KafkaClient.SendMessage(kafkaMsg)
-	return err
+
+	partition, offset, err := r.KafkaClient.SendMessage(kafkaMsg)
+	if err != nil {
+		return errors.Trace(err)
+	}
+	log.Infof("Produced message %s to kafka cluster partition %d with offset %d", msg, partition, offset)
+	return nil
 }
 
 //TransferData transfers AlertData to string and sends message to kafka
@@ -82,12 +99,12 @@ func (r *Run) TransferData(ad *AlertData) {
 
 		alertByte, err := json.Marshal(kafkaMsg)
 		if err != nil {
-			log.Errorf("can not marshal KafkaMsg with error %v", err)
+			log.Errorf("Failed to marshal KafkaMsg: %v", err)
 			continue
 		}
 
 		if err := r.PushKafkaMsg(string(alertByte)); err != nil {
-			log.Errorf("sending message to kafka with error %v", err)
+			log.Errorf("Failed to produce message to kafka cluster: %v", err)
 		}
 	}
 }

--- a/kafka-adapter/kafka.go
+++ b/kafka-adapter/kafka.go
@@ -112,12 +112,10 @@ func (r *Run) TransferData(ad *AlertData) {
 //Scheduler for monitoring chan data
 func (r *Run) Scheduler() {
 	for {
-		lenAlertMsgs := len(r.AlertMsgs)
-		if lenAlertMsgs > 0 {
-			for i := 0; i < lenAlertMsgs; i++ {
-				r.TransferData(<-r.AlertMsgs)
-			}
+		for alert := range r.AlertMsgs {
+			r.TransferData(alert)
 		}
+
 		time.Sleep(3 * time.Second)
 	}
 }

--- a/kafka-adapter/kafka.go
+++ b/kafka-adapter/kafka.go
@@ -19,7 +19,7 @@ const (
 //KafkaMsg represents kafka message
 type KafkaMsg struct {
 	Title       string `json:"event_object"`
-	Source      string `json:"objec_name"`
+	Source      string `json:"object_name"`
 	Instance    string `json:"object_ip"`
 	Description string `json:"event_msg"`
 	Time        string `json:"event_time"`

--- a/kafka-adapter/kafka.go
+++ b/kafka-adapter/kafka.go
@@ -18,16 +18,16 @@ const (
 
 //KafkaMsg represents kafka message
 type KafkaMsg struct {
-	Title       string `json:"title"`
-	Source      string `json:"source"`
-	Node        string `json:"node"`
+	Title       string `json:"event_object"`
+	Source      string `json:"objec_name"`
+	Instance    string `json:"object_ip"`
+	Description string `json:"event_msg"`
+	Time        string `json:"event_time"`
+	Level       string `json:"event_level"`
+	Summary     string `json:"summary"`
 	Expr        string `json:"expr"`
-	Description string `json:"description"`
-	URL         string `json:"url"`
-	Level       string `json:"level"`
-	Note        string `json:"note"`
 	Value       string `json:"value"`
-	Time        string `json:"time"`
+	URL         string `json:"url"`
 }
 
 //Run represents runtime information
@@ -86,15 +86,15 @@ func (r *Run) TransferData(ad *AlertData) {
 	for _, alert := range ad.Alerts {
 		kafkaMsg := &KafkaMsg{
 			Title:       getValue(alert.Labels, "alertname"),
-			Description: getValue(alert.Annotations, "description"),
-			Expr:        getValue(alert.Labels, "expr"),
-			Level:       getValue(alert.Labels, "level"),
-			Node:        getValue(alert.Labels, "instance"),
 			Source:      getValue(alert.Labels, "env"),
-			Value:       getValue(alert.Annotations, "value"),
-			Note:        getValue(alert.Annotations, "summary"),
-			URL:         alert.GeneratorURL,
+			Instance:    getValue(alert.Labels, "instance"),
+			Description: getValue(alert.Annotations, "description"),
 			Time:        alert.StartsAt.Format(timeFormat),
+			Level:       getValue(alert.Labels, "level"),
+			Summary:     getValue(alert.Annotations, "summary"),
+			Expr:        getValue(alert.Labels, "expr"),
+			Value:       getValue(alert.Annotations, "value"),
+			URL:         alert.GeneratorURL,
 		}
 
 		alertByte, err := json.Marshal(kafkaMsg)

--- a/kafka-adapter/main.go
+++ b/kafka-adapter/main.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"strings"
 	"syscall"
 
 	"github.com/ngaut/log"
@@ -25,6 +26,8 @@ func main() {
 	if *kafkaAddress == "" {
 		log.Fatalf("missing parameter: -kafka-address")
 	}
+	addrs := strings.Split(*kafkaAddress, ",")
+
 	if *kafkaTopic == "" {
 		log.Fatalf("missing parameter: -kafka-topic")
 	}
@@ -43,9 +46,8 @@ func main() {
 		AlertMsgs: make(chan *AlertData, 1000),
 	}
 
-	if err := r.CreateKafkaProducer(); err != nil {
-		log.Errorf("create kafka producer with error %v", err)
-		return
+	if err := r.CreateKafkaProducer(addrs); err != nil {
+		log.Fatalf("Failed to create kafka producer with error: %v", err)
 	}
 
 	go r.Scheduler()

--- a/kafka-adapter/main.go
+++ b/kafka-adapter/main.go
@@ -63,7 +63,6 @@ func main() {
 	go func() {
 		sig := <-sc
 		log.Infof("got signal [%d] to exit", sig)
-		close(r.AlertMsgs)
 		r.KafkaClient.Close()
 		os.Exit(0)
 	}()

--- a/kafka-adapter/main.go
+++ b/kafka-adapter/main.go
@@ -62,7 +62,8 @@ func main() {
 
 	go func() {
 		sig := <-sc
-		log.Infof("got signal [%d] to exit.", sig)
+		log.Infof("got signal [%d] to exit", sig)
+		close(r.AlertMsgs)
 		r.KafkaClient.Close()
 		os.Exit(0)
 	}()


### PR DESCRIPTION
- using default config.Producer.Partitioner(By default, Sarama uses the message's key to consistently assign a partition to a message using hashing. If no key is set, a random partition will be chosen. )
- and retry when NewSyncProducer
- close AlertMsgs channel when stopping kafka-adapter