### PR TITLE
grafana_collector:  implement "Repeating Rows" logic of grafana 

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -2,154 +2,201 @@
 
 
 [[projects]]
+  digest = "1:b16fbfbcc20645cb419f78325bb2e85ec729b338e996a228124d68931a6f2a37"
   name = "github.com/BurntSushi/toml"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b26d9c308763d68093482582cea63d69be07a0f0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:1e283d7680f5395cddb88a422783c8877ff60c28fc1d8fde27c808f1720c512e"
   name = "github.com/Shopify/sarama"
   packages = ["."]
+  pruneopts = "UT"
   revision = "f7be6aa2bc7b2e38edf816b08b582782194a1c02"
   version = "v1.16.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:315c5f2f60c76d89b871c73f9bd5fe689cad96597afd50fb9992228ef80bdd34"
   name = "github.com/alecthomas/template"
   packages = [
     ".",
-    "parse"
+    "parse",
   ]
+  pruneopts = "UT"
   revision = "a0175ee3bccc567396460bf5acd36800cb10c49c"
 
 [[projects]]
   branch = "master"
+  digest = "1:c198fdc381e898e8fb62b8eb62758195091c313ad18e52a3067366e1dda2fb3c"
   name = "github.com/alecthomas/units"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2efee857e7cfd4f3d0138cc3cbb1b4966962b93a"
 
 [[projects]]
   branch = "master"
+  digest = "1:d6afaeed1502aa28e80a4ed0981d570ad91b2579193404256ce672ed0a609e0d"
   name = "github.com/beorn7/perks"
   packages = ["quantile"]
+  pruneopts = "UT"
   revision = "3a771d992973f24aa725d07868b467d1ddfceafb"
 
 [[projects]]
+  digest = "1:a2c1d0e43bd3baaa071d1b9ed72c27d78169b2b269f71c105ac4ba34b1be4a39"
   name = "github.com/davecgh/go-spew"
   packages = ["spew"]
+  pruneopts = "UT"
   revision = "346938d642f2ec3594ed81d874461961cd0faa76"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:1f0c7ab489b407a7f8f9ad16c25a504d28ab461517a971d341388a56156c1bd7"
   name = "github.com/eapache/go-resiliency"
   packages = ["breaker"]
+  pruneopts = "UT"
   revision = "ea41b0fad31007accc7f806884dcdf3da98b79ce"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:2b55f08306f24f60dab51e006c1890db08d34ccc1b92c53a08a1a6e7792e3eb8"
   name = "github.com/eapache/go-xerial-snappy"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bb955e01b9346ac19dc29eb16586c90ded99a98c"
 
 [[projects]]
+  digest = "1:444b82bfe35c83bbcaf84e310fb81a1f9ece03edfed586483c869e2c046aef69"
   name = "github.com/eapache/queue"
   packages = ["."]
+  pruneopts = "UT"
   revision = "44cc805cf13205b55f69e14bcb69867d1ae92f98"
   version = "v1.1.0"
 
 [[projects]]
+  digest = "1:850c49ca338a10fec2cb9e78f793043ed23965489d09e30bcc19fe29719da313"
   name = "github.com/go-sql-driver/mysql"
   packages = ["."]
+  pruneopts = "UT"
   revision = "a0583e0143b1624142adab07e0e97fe106d99561"
   version = "v1.3.0"
 
 [[projects]]
+  digest = "1:17fe264ee908afc795734e8c4e63db2accabaf57326dbf21763a7d6b86096260"
   name = "github.com/golang/protobuf"
   packages = [
     "proto",
     "ptypes",
     "ptypes/any",
     "ptypes/duration",
-    "ptypes/timestamp"
+    "ptypes/timestamp",
   ]
+  pruneopts = "UT"
   revision = "b4deda0973fb4c70b50d226b1af49f3da59f5265"
   version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:29a5ab9fa9e845fd8e8726f31b187d710afd271ef1eb32085fe3d604b7e06382"
   name = "github.com/golang/snappy"
   packages = ["."]
+  pruneopts = "UT"
   revision = "553a641470496b2327abcac10b36396bd98e45c9"
 
 [[projects]]
   branch = "master"
+  digest = "1:f14d1b50e0075fb00177f12a96dd7addf93d1e2883c25befd17285b779549795"
   name = "github.com/gopherjs/gopherjs"
   packages = ["js"]
+  pruneopts = "UT"
   revision = "827bd480590f537dd1c934ce76fac24ea7ce9cae"
 
 [[projects]]
+  digest = "1:160eabf7a69910fd74f29c692718bc2437c1c1c7d4c9dea9712357752a70e5df"
   name = "github.com/gorilla/context"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1ea25387ff6f684839d82767c1733ff4d4d15d0a"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:88aa9e326e2bd6045a46e00a922954b3e1a9ac5787109f49ac85366df370e1e5"
   name = "github.com/gorilla/mux"
   packages = ["."]
+  pruneopts = "UT"
   revision = "53c1911da2b537f792e7cafcb446b05ffe33b996"
   version = "v1.6.1"
 
 [[projects]]
+  digest = "1:1e15f4e455f94aeaedfcf9c75b3e1c449b5acba1551c58446b4b45be507c707b"
   name = "github.com/jtolds/gls"
   packages = ["."]
+  pruneopts = "UT"
   revision = "77f18212c9c7edc9bd6a33d383a7b545ce62f064"
   version = "v4.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:70107cf7ee5eb9e3c3dabe65bcb220bff22ee42e32d9b7fca988e16b8727cacc"
   name = "github.com/juju/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c7d06af17c68cd34c835053720b21f6549d9b0ee"
 
 [[projects]]
+  digest = "1:ff5ebae34cfbf047d505ee150de27e60570e8c394b3b8fdbb720ff6ac71985fc"
   name = "github.com/matttproud/golang_protobuf_extensions"
   packages = ["pbutil"]
+  pruneopts = "UT"
   revision = "c12348ce28de40eed0136aa2b644d0ee0650e56c"
   version = "v1.0.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:902a3867d00c57b3fcc17634d88e1d811b85c0b3e3b4b3a1633869066fcad84e"
   name = "github.com/ngaut/log"
   packages = ["."]
+  pruneopts = "UT"
   revision = "b8e36e7ba5ac61ce5644e570f1cc42d97dbaf8ed"
 
 [[projects]]
+  digest = "1:361de06aa7ae272616cbe71c3994a654cc6316324e30998e650f7765b20c5b33"
   name = "github.com/pborman/uuid"
   packages = ["."]
+  pruneopts = "UT"
   revision = "e790cca94e6cc75c7064b1332e63811d4aae1a53"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:34833843589f17bb48234a8cdd36b1038aed85a09d60e30fc73891b7d89b6c1d"
   name = "github.com/pierrec/lz4"
   packages = ["."]
+  pruneopts = "UT"
   revision = "2fcda4cb7018ce05a25959d2fe08c83e3329f169"
   version = "v1.1"
 
 [[projects]]
+  digest = "1:186e021e0c2fa61e181151d8b2fef4d2b6b217a55794bd591de73773b934a32a"
   name = "github.com/pierrec/xxHash"
   packages = ["xxHash32"]
+  pruneopts = "UT"
   revision = "f051bb7f1d1aaf1b5a665d74fb6b0217712c69f7"
   version = "v0.1.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:0503a20c05af88acb169de2308c84d8df06ba94328ddd7a38085ebafe6aedfb7"
   name = "github.com/pingcap/check"
   packages = ["."]
+  pruneopts = "UT"
   revision = "1c287c953996ab3a0bf535dba9d53d809d3dc0b6"
 
 [[projects]]
   branch = "master"
+  digest = "1:2883c770bb27ebd87d800a32961aea3c65ae4f67fdf957dddb1995fb210efd2b"
   name = "github.com/pingcap/kvproto"
   packages = [
     "pkg/debugpb",
@@ -157,89 +204,109 @@
     "pkg/errorpb",
     "pkg/kvrpcpb",
     "pkg/metapb",
-    "pkg/raft_serverpb"
+    "pkg/raft_serverpb",
   ]
+  pruneopts = "UT"
   revision = "5e6e69a5ed381bd4a8afe7cb96cc47f955f6d160"
 
 [[projects]]
+  digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
   name = "github.com/prometheus/client_golang"
   packages = [
     "prometheus",
-    "prometheus/promhttp"
+    "prometheus/promhttp",
   ]
+  pruneopts = "UT"
   revision = "c5b7fccd204277076155f10851dad72b76a49317"
   version = "v0.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:32d10bdfa8f09ecf13598324dba86ab891f11db3c538b6a34d1c3b5b99d7c36b"
   name = "github.com/prometheus/client_model"
   packages = ["go"]
+  pruneopts = "UT"
   revision = "99fa1f4be8e564e8a6b613da7fa6f46c9edafc6c"
 
 [[projects]]
   branch = "master"
+  digest = "1:e469cd65badf7694aeb44874518606d93c1d59e7735d3754ad442782437d3cc3"
   name = "github.com/prometheus/common"
   packages = [
     "expfmt",
     "internal/bitbucket.org/ww/goautoneg",
-    "model"
+    "model",
   ]
+  pruneopts = "UT"
   revision = "7600349dcfe1abd18d72d3a1770870d9800a7801"
 
 [[projects]]
   branch = "master"
+  digest = "1:570784e0ddbf67f14087c6d8cfb7b999b9c55e75518a755e88cb202566ea8a17"
   name = "github.com/prometheus/procfs"
   packages = [
     ".",
     "internal/util",
     "nfs",
-    "xfs"
+    "xfs",
   ]
+  pruneopts = "UT"
   revision = "94663424ae5ae9856b40a9f170762b4197024661"
 
 [[projects]]
   branch = "master"
+  digest = "1:f0cbafdbea55828a9bf72cc1a2fc61b50a6cea0bfdb34300a8204618c7a72309"
   name = "github.com/rcrowley/go-metrics"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d932a24a8ccb8fcadc993e5c6c58f93dac168294"
 
 [[projects]]
   branch = "master"
+  digest = "1:f5861ea22d79a2f3c13ff89f476b33f854db44619cb6ec10cf9fea4430173f1e"
   name = "github.com/signintech/gopdf"
   packages = [
     ".",
-    "fontmaker/core"
+    "fontmaker/core",
   ]
+  pruneopts = "UT"
   revision = "55ea01955b8489e8aae0f85d4aaa0ae72ace0053"
 
 [[projects]]
+  digest = "1:cc1c574c9cb5e99b123888c12b828e2d19224ab6c2244bda34647f230bf33243"
   name = "github.com/smartystreets/assertions"
   packages = [
     ".",
     "internal/go-render/render",
-    "internal/oglematchers"
+    "internal/oglematchers",
   ]
+  pruneopts = "UT"
   revision = "7678a5452ebea5b7090a6b163f844c133f523da2"
   version = "1.8.3"
 
 [[projects]]
+  digest = "1:a3e081e593ee8e3b0a9af6a5dcac964c67a40c4f2034b5345b2ad78d05920728"
   name = "github.com/smartystreets/goconvey"
   packages = [
     "convey",
     "convey/gotest",
-    "convey/reporting"
+    "convey/reporting",
   ]
+  pruneopts = "UT"
   revision = "9e8dc3f972df6c8fcc0375ef492c24d0bb204857"
   version = "1.6.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:e833d953c8467158fd0250a053ec390dd899945d4c6b87b07920ad431fc80dfe"
   name = "github.com/unrolled/render"
   packages = ["."]
+  pruneopts = "UT"
   revision = "65450fb6b2d3595beca39f969c411db8f8d5c806"
 
 [[projects]]
   branch = "master"
+  digest = "1:35dc91eff9861545fea1fd5e723a72202aaeb668f7cda7c415a226ea9e00c35d"
   name = "golang.org/x/net"
   packages = [
     "context",
@@ -248,11 +315,13 @@
     "http2/hpack",
     "idna",
     "internal/timeseries",
-    "trace"
+    "trace",
   ]
+  pruneopts = "UT"
   revision = "a680a1efc54dd51c040b3b5ce4939ea3cf2ea0d1"
 
 [[projects]]
+  digest = "1:a2ab62866c75542dd18d2b069fec854577a20211d7c0ea6ae746072a1dccdd18"
   name = "golang.org/x/text"
   packages = [
     "collate",
@@ -268,18 +337,22 @@
     "unicode/bidi",
     "unicode/cldr",
     "unicode/norm",
-    "unicode/rangetable"
+    "unicode/rangetable",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:601e63e7d4577f907118bec825902505291918859d223bce015539e79f1160e3"
   name = "google.golang.org/genproto"
   packages = ["googleapis/rpc/status"]
+  pruneopts = "UT"
   revision = "fedd2861243fd1a8152376292b921b394c7bef7e"
 
 [[projects]]
+  digest = "1:2dab32a43451e320e49608ff4542fdfc653c95dcc35d0065ec9c6c3dd540ed74"
   name = "google.golang.org/grpc"
   packages = [
     ".",
@@ -306,20 +379,44 @@
     "stats",
     "status",
     "tap",
-    "transport"
+    "transport",
   ]
+  pruneopts = "UT"
   revision = "168a6198bcb0ef175f7dacec0b8691fc141dc9b8"
   version = "v1.13.0"
 
 [[projects]]
+  digest = "1:c06d9e11d955af78ac3bbb26bd02e01d2f61f689e1a3bce2ef6fb683ef8a7f2d"
   name = "gopkg.in/alecthomas/kingpin.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "947dcec5ba9c011838740e680966fd7087a71d0d"
   version = "v2.2.6"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "47df26d26ca6ada160b9e9ae2fbc4de94990e8538d1ab341e4645b394dc3220c"
+  input-imports = [
+    "github.com/BurntSushi/toml",
+    "github.com/Shopify/sarama",
+    "github.com/go-sql-driver/mysql",
+    "github.com/golang/protobuf/proto",
+    "github.com/gorilla/mux",
+    "github.com/juju/errors",
+    "github.com/ngaut/log",
+    "github.com/pborman/uuid",
+    "github.com/pingcap/check",
+    "github.com/pingcap/kvproto/pkg/debugpb",
+    "github.com/prometheus/client_golang/prometheus",
+    "github.com/prometheus/client_golang/prometheus/promhttp",
+    "github.com/prometheus/client_model/go",
+    "github.com/prometheus/common/expfmt",
+    "github.com/signintech/gopdf",
+    "github.com/smartystreets/goconvey/convey",
+    "github.com/unrolled/render",
+    "google.golang.org/grpc",
+    "google.golang.org/grpc/credentials",
+    "gopkg.in/alecthomas/kingpin.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -210,6 +210,14 @@
   revision = "5e6e69a5ed381bd4a8afe7cb96cc47f955f6d160"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
+  name = "github.com/pkg/errors"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
+  version = "v0.8.0"
+
+[[projects]]
   digest = "1:d14a5f4bfecf017cb780bdde1b6483e5deb87e12c332544d2c430eda58734bcb"
   name = "github.com/prometheus/client_golang"
   packages = [
@@ -407,6 +415,7 @@
     "github.com/pborman/uuid",
     "github.com/pingcap/check",
     "github.com/pingcap/kvproto/pkg/debugpb",
+    "github.com/pkg/errors",
     "github.com/prometheus/client_golang/prometheus",
     "github.com/prometheus/client_golang/prometheus/promhttp",
     "github.com/prometheus/client_model/go",

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ test:
 	$(GOTEST) -cover $(PACKAGES)
 
 check:
-	$(GO) get github.com/golang/lint/golint
+	$(GO) get golang.org/x/lint/golint
 
 	$(GO) tool vet . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'
 	$(GO) tool vet --shadow . 2>&1 | grep -vE 'vendor' | awk '{print} END{if(NR>0) {exit 1}}'

--- a/cmd/grafana_collector/handler_test.go
+++ b/cmd/grafana_collector/handler_test.go
@@ -35,7 +35,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"testing"
 
 	"github.com/gorilla/mux"
@@ -57,11 +56,9 @@ func TestV4ServeReportHandler(t *testing.T) {
 	Convey("When the v4 report server handler is called", t, func() {
 		//mock new grafana client function to capture and validate its input parameters
 		var clAPIToken string
-		var clVars url.Values
-		newGrafanaClient := func(url string, apiToken string, variables url.Values) grafana.Client {
+		newGrafanaClient := func(url string, apiToken string, timeRange grafana.TimeRange) grafana.Client {
 			clAPIToken = apiToken
-			clVars = variables
-			return grafana.NewV4Client(url, apiToken, variables)
+			return grafana.NewV4Client(url, apiToken, timeRange)
 		}
 		//mock new report function to capture and validate its input parameters
 		var repDashName string
@@ -85,22 +82,6 @@ func TestV4ServeReportHandler(t *testing.T) {
 			router.ServeHTTP(rec, req)
 			So(clAPIToken, ShouldEqual, "1234")
 		})
-
-		Convey("It should extract the grafana variables and forward them to the new Grafana Client ", func() {
-			req, _ := http.NewRequest("GET", "/api/report/testDash?var-test=testValue", nil)
-			router.ServeHTTP(rec, req)
-			expected := url.Values{}
-			expected.Add("var-test", "testValue")
-			So(clVars, ShouldResemble, expected)
-
-			Convey("Variables should not contain other query parameters ", func() {
-				req, _ := http.NewRequest("GET", "/api/report/testDash?var-test=testValue&apitoken=1234", nil)
-				router.ServeHTTP(rec, req)
-				expected := url.Values{}
-				expected.Add("var-test", "testValue") //apitoken not expected here
-				So(clVars, ShouldResemble, expected)
-			})
-		})
 	})
 }
 
@@ -108,11 +89,9 @@ func TestV5ServeReportHandler(t *testing.T) {
 	Convey("When the v5 report server handler is called", t, func() {
 		//mock new grafana client function to capture and validate its input parameters
 		var clAPIToken string
-		var clVars url.Values
-		newGrafanaClient := func(url string, apiToken string, variables url.Values) grafana.Client {
+		newGrafanaClient := func(url string, apiToken string, timeRange grafana.TimeRange) grafana.Client {
 			clAPIToken = apiToken
-			clVars = variables
-			return grafana.NewV4Client(url, apiToken, variables)
+			return grafana.NewV5Client(url, apiToken, timeRange)
 		}
 		//mock new report function to capture and validate its input parameters
 		var repDashName string
@@ -135,22 +114,6 @@ func TestV5ServeReportHandler(t *testing.T) {
 			req, _ := http.NewRequest("GET", "/api/v5/report/testDash?apitoken=1234", nil)
 			router.ServeHTTP(rec, req)
 			So(clAPIToken, ShouldEqual, "1234")
-		})
-
-		Convey("It should extract the grafana variables and forward them to the new Grafana Client ", func() {
-			req, _ := http.NewRequest("GET", "/api/v5/report/testDash?var-test=testValue", nil)
-			router.ServeHTTP(rec, req)
-			expected := url.Values{}
-			expected.Add("var-test", "testValue")
-			So(clVars, ShouldResemble, expected)
-
-			Convey("Variables should not contain other query parameters ", func() {
-				req, _ := http.NewRequest("GET", "/api/v5/report/testDash?var-test=testValue&apitoken=1234", nil)
-				router.ServeHTTP(rec, req)
-				expected := url.Values{}
-				expected.Add("var-test", "testValue") //apitoken not expected here
-				So(clVars, ShouldResemble, expected)
-			})
 		})
 	})
 }

--- a/cmd/grafana_collector/main.go
+++ b/cmd/grafana_collector/main.go
@@ -92,7 +92,7 @@ func main() {
 		}
 	}
 
-	log.Infof("serving at '%s' and using grafana at '%s%s'", *port, *proto, *ip)
+	log.Infof("grafana_collector is serving at '%s' and using grafana at '%s%s'", *port, *proto, *ip)
 
 	router := mux.NewRouter()
 	RegisterHandlers(

--- a/cmd/grafana_collector/main.go
+++ b/cmd/grafana_collector/main.go
@@ -78,7 +78,7 @@ func main() {
 	}
 
 	if *fontDir == "" {
-		log.Fatalf("missing parameter: -font-dir")
+		log.Fatal("missing parameter: -font-dir")
 	}
 	report.SetFontDir(*fontDir)
 

--- a/grafana_collector/config/config.go
+++ b/grafana_collector/config/config.go
@@ -32,10 +32,12 @@ type rect struct {
 }
 
 type position struct {
-	X  float64
-	Y1 float64
-	Y2 float64
-	Br float64
+	X       float64
+	TitleY1 float64 `toml:"title-y1"`
+	TitleY2 float64 `toml:"title-y2"`
+	ImageY1 float64 `toml:"image-y1"`
+	ImageY2 float64 `toml:"image-y2"`
+	Br      float64
 }
 
 var defaultConf = Config{
@@ -60,15 +62,17 @@ var defaultConf = Config{
 			Height: 240.0,
 		},
 		"singlestat": {
-			Width:  300.0,
-			Height: 150.0,
+			Width:  480.0,
+			Height: 93.0,
 		},
 	},
 	Position: position{
-		X:  50.0,
-		Y1: 80.0,
-		Y2: 350.0,
-		Br: 20.0,
+		X:       50.0,
+		TitleY1: 60.0,
+		TitleY2: 350.0,
+		ImageY1: 80.0,
+		ImageY2: 370.0,
+		Br:      20.0,
 	},
 }
 

--- a/grafana_collector/config/grafana_collector.toml
+++ b/grafana_collector/config/grafana_collector.toml
@@ -29,15 +29,19 @@ height = 240.0
 
 # grafana panel type: Singlestat
 [rect.singlestat]
-width = 300.0
-height = 150.0
+width = 480.0
+height = 93.0
 
 [position]
 # position x of image
 x = 50.0
+# position y of first title on page
+title-y1 = 60.0
+# position y of second title on page
+title-y2 = 350.0
 # position y of first image on page
-y1 = 80.0
+image-y1 = 80.0
 # position y of second image on page
-y2 = 350.0
+image-y2 = 370.0
 # height of new line
 br = 20.0

--- a/grafana_collector/grafana/api.go
+++ b/grafana_collector/grafana/api.go
@@ -32,7 +32,6 @@ package grafana
 import (
 	"errors"
 	"fmt"
-	"github.com/ngaut/log"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -40,6 +39,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/ngaut/log"
 	"github.com/pingcap/tidb-inspect-tools/grafana_collector/config"
 )
 
@@ -63,7 +63,8 @@ type client struct {
 
 // NewV4Client creates a new Grafana 4 Client. If apiToken is the empty string,
 // authorization headers will be omitted from requests.
-// variables are Grafana template variable url values of the form var-{name}={value}, e.g. var-host=dev
+// variables are Grafana template variable url values of the form
+// var-{name}={value}, e.g. var-host=dev
 func NewV4Client(grafanaURL string, apiToken string, variables url.Values) Client {
 	getDashEndpoint := func(dashName string) string {
 		dashURL := grafanaURL + "/api/dashboards/db/" + dashName
@@ -81,7 +82,8 @@ func NewV4Client(grafanaURL string, apiToken string, variables url.Values) Clien
 
 // NewV5Client creates a new Grafana 5 Client. If apiToken is the empty string,
 // authorization headers will be omitted from requests.
-// variables are Grafana template variable url values of the form var-{name}={value}, e.g. var-host=dev
+// variables are Grafana template variable url values of the form
+// var-{name}={value}, e.g. var-host=dev
 func NewV5Client(grafanaURL string, apiToken string, variables url.Values) Client {
 	getDashEndpoint := func(dashName string) string {
 		dashURL := grafanaURL + "/api/dashboards/uid/" + dashName
@@ -126,7 +128,7 @@ func (g client) GetDashboard(dashName string) (Dashboard, error) {
 		return Dashboard{}, fmt.Errorf("error obtaining dashboard from %v. Got Status %v, message: %v ", dashURL, resp.Status, string(body))
 	}
 
-	return NewDashboard(body, g.variables), nil
+	return NewDashboard(body, g.url, g.apiToken, g.variables), nil
 }
 
 func (g client) GetPanelPng(p Panel, dashName string, t TimeRange) (io.ReadCloser, error) {

--- a/grafana_collector/grafana/api.go
+++ b/grafana_collector/grafana/api.go
@@ -184,8 +184,8 @@ func (g client) getPanelURL(p Panel, dashName string, t TimeRange) string {
 	values.Add("from", t.From)
 	values.Add("to", t.To)
 	if p.IsSingleStat() {
-		values.Add("width", "300")
-		values.Add("height", "150")
+		values.Add("width", "480")
+		values.Add("height", "93")
 	} else {
 		values.Add("width", "1000")
 		values.Add("height", "500")

--- a/grafana_collector/grafana/dashboard.go
+++ b/grafana_collector/grafana/dashboard.go
@@ -127,7 +127,7 @@ func (d *Dashboard) getTemplatingVariableValue(tv TemplatingVariable) ([]string,
 
 	log.Infof("request metric at %s\n", metricURL)
 
-	clientTimeout := time.Duration(300) * time.Second
+	clientTimeout := time.Duration(60) * time.Second
 	client := &http.Client{Timeout: clientTimeout}
 	req, err := http.NewRequest("GET", metricURL, nil)
 	if err != nil {
@@ -165,10 +165,6 @@ func (d *Dashboard) getTemplatingVariableValue(tv TemplatingVariable) ([]string,
 }
 
 func (d *Dashboard) process() {
-	if len(d.Templating["list"]) == 0 {
-		return
-	}
-
 	for i := 0; i < len(d.Rows); i++ {
 		row := d.Rows[i]
 		if row.Repeat != "" {
@@ -305,7 +301,7 @@ func populatePanelsFromV4JSON(dash Dashboard, dc dashContainer) Dashboard {
 		dash.Rows = append(dash.Rows, row)
 	}
 
-	// handle row repeats
+	// handle Row repeats and RowTitle
 	dash.process()
 
 	for _, row := range dash.Rows {

--- a/grafana_collector/grafana/dashboard.go
+++ b/grafana_collector/grafana/dashboard.go
@@ -79,15 +79,14 @@ type TemplatingVariable struct {
 // Dashboard represents a Grafana dashboard
 // This is used to unmarshal the dashbaord JSON
 type Dashboard struct {
-	Title          string
-	Templating     map[string][]TemplatingVariable
-	Rows           []Row
-	Panels         []Panel
-	VariableValues string
-	url            string
-	apiToken       string
-	timeRange      TimeRange
-	iteration      int
+	Title      string
+	Templating map[string][]TemplatingVariable
+	Rows       []Row
+	Panels     []Panel
+	url        string
+	apiToken   string
+	timeRange  TimeRange
+	iteration  int
 }
 
 type dashContainer struct {
@@ -262,13 +261,13 @@ func (d *Dashboard) getNextPanelID() int {
 }
 
 // NewDashboard creates Dashboard from Grafana's internal JSON dashboard definition
-func NewDashboard(dashJSON []byte, url string, apiToken string, variables url.Values, timeRange TimeRange) Dashboard {
+func NewDashboard(dashJSON []byte, url string, apiToken string, timeRange TimeRange) Dashboard {
 	var dash dashContainer
 	err := json.Unmarshal(dashJSON, &dash)
 	if err != nil {
 		panic(err)
 	}
-	d := dash.NewDashboard(url, apiToken, variables, timeRange)
+	d := dash.NewDashboard(url, apiToken, timeRange)
 
 	b, err := json.MarshalIndent(d, "", "    ")
 	if err != nil {
@@ -278,13 +277,12 @@ func NewDashboard(dashJSON []byte, url string, apiToken string, variables url.Va
 	return d
 }
 
-func (dc dashContainer) NewDashboard(url string, apiToken string, variables url.Values, timeRange TimeRange) Dashboard {
+func (dc dashContainer) NewDashboard(url string, apiToken string, timeRange TimeRange) Dashboard {
 	var dash Dashboard
 	iteration := int(time.Now().UnixNano() / int64(time.Millisecond))
 
 	dash.Title = dc.Dashboard.Title
 	dash.Templating = dc.Dashboard.Templating
-	dash.VariableValues = getVariablesValues(variables)
 	dash.url = url
 	dash.apiToken = apiToken
 	dash.iteration = iteration

--- a/grafana_collector/grafana/dashboard.go
+++ b/grafana_collector/grafana/dashboard.go
@@ -38,9 +38,10 @@ import (
 
 // Panel represents a Grafana dashboard panel
 type Panel struct {
-	ID    int
-	Type  string // Panel Type: Graph/Singlestat
-	Title string
+	ID       int
+	Type     string // Panel Type: Graph/Singlestat
+	Title    string
+	RowTitle string
 }
 
 // Row represents a container for Panels
@@ -92,7 +93,9 @@ func (dc dashContainer) NewDashboard(variables url.Values) Dashboard {
 
 func populatePanelsFromV4JSON(dash Dashboard, dc dashContainer) Dashboard {
 	for _, row := range dc.Dashboard.Rows {
+		rowTitle := row.Title
 		for i, p := range row.Panels {
+			p.RowTitle = rowTitle
 			row.Panels[i] = p
 			dash.Panels = append(dash.Panels, p)
 		}

--- a/grafana_collector/grafana/dashboard_test.go
+++ b/grafana_collector/grafana/dashboard_test.go
@@ -55,9 +55,10 @@ func TestV4Dashboard(t *testing.T) {
 "Meta":
 	{"Slug":"testDash"}
 }`
-		dash := NewDashboard([]byte(v4DashJSON), "", "", TimeRange{"now-1h", "now"})
+		dash, err := NewDashboard([]byte(v4DashJSON), "", "", TimeRange{"now-1h", "now"})
 
 		Convey("Panel IsSingelStat should work for all panels", func() {
+			So(err, ShouldBeNil)
 			So(dash.Panels[0].IsSingleStat(), ShouldBeTrue)
 			So(dash.Panels[1].IsSingleStat(), ShouldBeFalse)
 			So(dash.Panels[2].IsSingleStat(), ShouldBeTrue)
@@ -85,9 +86,10 @@ func TestV5Dashboard(t *testing.T) {
 "Meta":
 	{"Slug":"testDash"}
 }`
-		dash := NewDashboard([]byte(v5DashJSON), "", "", TimeRange{"now-1h", "now"})
+		dash, err := NewDashboard([]byte(v5DashJSON), "", "", TimeRange{"now-1h", "now"})
 
 		Convey("Panel IsSingelStat should work for all panels", func() {
+			So(err, ShouldBeNil)
 			So(dash.Panels[0].IsSingleStat(), ShouldBeTrue)
 			So(dash.Panels[1].IsSingleStat(), ShouldBeFalse)
 			So(dash.Panels[2].IsSingleStat(), ShouldBeTrue)
@@ -98,6 +100,38 @@ func TestV5Dashboard(t *testing.T) {
 			So(dash.Panels[0].ID, ShouldEqual, 0)
 			So(dash.Panels[1].ID, ShouldEqual, 1)
 			So(dash.Panels[2].ID, ShouldEqual, 2)
+		})
+	})
+}
+
+func TestGetMetricAndLabel(t *testing.T) {
+	Convey("When analysing a correct TemplatingVariable ", t, func() {
+		variable := TemplatingVariable{"db", "test-cluster", "label_values(tikv_engine_block_cache_size_bytes, db)"}
+		metric, label, err := getMetricAndLabel(variable)
+
+		Convey("metric and label should not be empty and correct", func() {
+			So(err, ShouldBeNil)
+			So(metric, ShouldEqual, "tikv_engine_block_cache_size_bytes")
+			So(label, ShouldEqual, "db")
+		})
+	})
+}
+
+func TestGetMetricAndLabelErrorHandling(t *testing.T) {
+	Convey("When analysing a wrong TemplatingVariable", t, func() {
+		v1 := TemplatingVariable{"db", "test-cluster", "label_values(tikv_engine_block_cache_size_bytes, 2db)"}
+		v2 := TemplatingVariable{"db", "test-cluster", "db, db"}
+
+		metric1, label1, err1 := getMetricAndLabel(v1)
+		metric2, label2, err2 := getMetricAndLabel(v2)
+
+		Convey("should return error", func() {
+			So(err1, ShouldNotBeNil)
+			So(metric1, ShouldBeEmpty)
+			So(label1, ShouldBeEmpty)
+			So(err2, ShouldNotBeNil)
+			So(metric2, ShouldBeEmpty)
+			So(label2, ShouldBeEmpty)
 		})
 	})
 }

--- a/grafana_collector/grafana/dashboard_test.go
+++ b/grafana_collector/grafana/dashboard_test.go
@@ -30,7 +30,6 @@
 package grafana
 
 import (
-	"net/url"
 	"testing"
 
 	. "github.com/smartystreets/goconvey/convey"
@@ -56,7 +55,7 @@ func TestV4Dashboard(t *testing.T) {
 "Meta":
 	{"Slug":"testDash"}
 }`
-		dash := NewDashboard([]byte(v4DashJSON), url.Values{})
+		dash := NewDashboard([]byte(v4DashJSON), "", "", TimeRange{"now-1h", "now"})
 
 		Convey("Panel IsSingelStat should work for all panels", func() {
 			So(dash.Panels[0].IsSingleStat(), ShouldBeTrue)
@@ -86,7 +85,7 @@ func TestV5Dashboard(t *testing.T) {
 "Meta":
 	{"Slug":"testDash"}
 }`
-		dash := NewDashboard([]byte(v5DashJSON), url.Values{})
+		dash := NewDashboard([]byte(v5DashJSON), "", "", TimeRange{"now-1h", "now"})
 
 		Convey("Panel IsSingelStat should work for all panels", func() {
 			So(dash.Panels[0].IsSingleStat(), ShouldBeTrue)
@@ -99,26 +98,6 @@ func TestV5Dashboard(t *testing.T) {
 			So(dash.Panels[0].ID, ShouldEqual, 0)
 			So(dash.Panels[1].ID, ShouldEqual, 1)
 			So(dash.Panels[2].ID, ShouldEqual, 2)
-		})
-	})
-}
-
-func TestVariableValues(t *testing.T) {
-	Convey("When creating a dashboard and passing url varialbes in", t, func() {
-		const v5DashJSON = `
-{
-	"Dashboard":
-		{
-		}
-}`
-		vars := url.Values{}
-		vars.Add("var-one", "oneval")
-		vars.Add("var-two", "twoval")
-		dash := NewDashboard([]byte(v5DashJSON), vars)
-
-		Convey("The dashboard should contain the variable values in a random order", func() {
-			So(dash.VariableValues, ShouldContainSubstring, "oneval")
-			So(dash.VariableValues, ShouldContainSubstring, "twoval")
 		})
 	})
 }

--- a/grafana_collector/grafana/time.go
+++ b/grafana_collector/grafana/time.go
@@ -67,6 +67,11 @@ const (
 	boundaryTimeRegExp = "^(.*?)/([dwMy])$"
 )
 
+// NewIteration ... returns the number of milliseconds elapsed since January 1, 1970 UTC.
+func NewIteration() int {
+	return int(time.Now().UnixNano() / int64(time.Millisecond))
+}
+
 // NewTimeRange ... creates a new TimeRange
 func NewTimeRange(from, to string) TimeRange {
 	if from == "" {
@@ -167,7 +172,6 @@ func add(b boundary) int {
 	if b == To {
 		return 1
 	}
-	// b == From
 	return 0
 }
 
@@ -175,7 +179,6 @@ func daysToWeekBoundary(wd time.Weekday, b boundary) int {
 	if b == To {
 		return 1 + int(time.Saturday) - int(wd)
 	}
-	//b == From
 	return -int(wd)
 }
 

--- a/grafana_collector/grafana/time.go
+++ b/grafana_collector/grafana/time.go
@@ -78,6 +78,22 @@ func NewTimeRange(from, to string) TimeRange {
 	return TimeRange{from, to}
 }
 
+// FromToUnix ... Formats Grafana 'From' time spec into a Unix time, the number
+// of seconds elapsed since January 1, 1970 UTC.
+func (tr TimeRange) FromToUnix() int {
+	n := newNow()
+	t := n.parseFrom(tr.From)
+	return int(t.UnixNano() / int64(time.Second))
+}
+
+// ToToUnix ... Formats Grafana 'To' time spec into a Unix time, the number
+// of seconds elapsed since January 1, 1970 UTC.
+func (tr TimeRange) ToToUnix() int {
+	n := newNow()
+	t := n.parseFrom(tr.To)
+	return int(t.UnixNano() / int64(time.Second))
+}
+
 // FromFormatted ... Formats Grafana 'From' time spec into absolute printable UTC time
 func (tr TimeRange) FromFormatted() string {
 	n := newNow()

--- a/grafana_collector/grafana/time.go
+++ b/grafana_collector/grafana/time.go
@@ -67,9 +67,9 @@ const (
 	boundaryTimeRegExp = "^(.*?)/([dwMy])$"
 )
 
-// NewIteration ... returns the number of milliseconds elapsed since January 1, 1970 UTC.
-func NewIteration() int {
-	return int(time.Now().UnixNano() / int64(time.Millisecond))
+// UnixSecond ... returns the number of seconds elapsed since January 1, 1970 UTC.
+func UnixSecond(t time.Time) int64 {
+	return int64(t.UnixNano() / int64(time.Second))
 }
 
 // NewTimeRange ... creates a new TimeRange
@@ -85,18 +85,18 @@ func NewTimeRange(from, to string) TimeRange {
 
 // FromToUnix ... Formats Grafana 'From' time spec into a Unix time, the number
 // of seconds elapsed since January 1, 1970 UTC.
-func (tr TimeRange) FromToUnix() int {
+func (tr TimeRange) FromToUnix() int64 {
 	n := newNow()
 	t := n.parseFrom(tr.From)
-	return int(t.UnixNano() / int64(time.Second))
+	return UnixSecond(t)
 }
 
 // ToToUnix ... Formats Grafana 'To' time spec into a Unix time, the number
 // of seconds elapsed since January 1, 1970 UTC.
-func (tr TimeRange) ToToUnix() int {
+func (tr TimeRange) ToToUnix() int64 {
 	n := newNow()
-	t := n.parseFrom(tr.To)
-	return int(t.UnixNano() / int64(time.Second))
+	t := n.parseTo(tr.To)
+	return UnixSecond(t)
 }
 
 // FromFormatted ... Formats Grafana 'From' time spec into absolute printable UTC time

--- a/grafana_collector/report/report.go
+++ b/grafana_collector/report/report.go
@@ -253,14 +253,14 @@ func (rep *report) renderPDF(dash grafana.Dashboard) (outputPDF *os.File, err er
 		// Add two images on every page
 		if count%2 == 0 {
 			pdf.SetX(cfg.Position.X)
-			pdf.SetY(60.0)
+			pdf.SetY(cfg.Position.TitleY1)
 			pdf.Cell(nil, fmt.Sprintf("Row: %s, Panel: %s", p.RowTitle, p.Title))
-			err = pdf.Image(imgPath, cfg.Position.X, cfg.Position.Y1, rect)
+			err = pdf.Image(imgPath, cfg.Position.X, cfg.Position.ImageY1, rect)
 		} else {
 			pdf.SetX(cfg.Position.X)
-			pdf.SetY(330.0)
+			pdf.SetY(cfg.Position.TitleY2)
 			pdf.Cell(nil, fmt.Sprintf("Row: %s, Panel: %s", p.RowTitle, p.Title))
-			err = pdf.Image(imgPath, cfg.Position.X, cfg.Position.Y2, rect)
+			err = pdf.Image(imgPath, cfg.Position.X, cfg.Position.ImageY2, rect)
 			pdf.AddPage()
 		}
 		if err != nil {

--- a/grafana_collector/report/report.go
+++ b/grafana_collector/report/report.go
@@ -251,8 +251,14 @@ func (rep *report) renderPDF(dash grafana.Dashboard) (outputPDF *os.File, err er
 
 		// Add two images on every page
 		if count%2 == 0 {
+			pdf.SetX(cfg.Position.X)
+			pdf.SetY(60.0)
+			pdf.Cell(nil, fmt.Sprintf("Row: %s, Panel: %s", p.RowTitle, p.Title))
 			err = pdf.Image(imgPath, cfg.Position.X, cfg.Position.Y1, rect)
 		} else {
+			pdf.SetX(cfg.Position.X)
+			pdf.SetY(330.0)
+			pdf.Cell(nil, fmt.Sprintf("Row: %s, Panel: %s", p.RowTitle, p.Title))
 			err = pdf.Image(imgPath, cfg.Position.X, cfg.Position.Y2, rect)
 			pdf.AddPage()
 		}

--- a/grafana_collector/report/report.go
+++ b/grafana_collector/report/report.go
@@ -57,7 +57,8 @@ const (
 )
 
 // Report groups functions related to genrating the report.
-// After reading and closing the pdf returned by Generate(), call Clean() to delete the pdf file as well the temporary build files
+// After reading and closing the pdf returned by Generate(),
+// call Clean() to delete the pdf file as well the temporary build files
 type Report interface {
 	Generate() (pdf io.ReadCloser, err error)
 	Clean()

--- a/grafana_collector/report/report.go
+++ b/grafana_collector/report/report.go
@@ -36,11 +36,11 @@ import (
 	"path/filepath"
 	"sync"
 
-	"github.com/juju/errors"
 	"github.com/ngaut/log"
 	"github.com/pborman/uuid"
 	"github.com/pingcap/tidb-inspect-tools/grafana_collector/config"
 	"github.com/pingcap/tidb-inspect-tools/grafana_collector/grafana"
+	"github.com/pkg/errors"
 	"github.com/signintech/gopdf"
 )
 
@@ -206,14 +206,14 @@ func (rep *report) NewPDF() (*gopdf.GoPdf, error) {
 	ttfPath := FontDir + cfg.Font.Ttf
 	err := pdf.AddTTFFont(cfg.Font.Family, ttfPath)
 	if err != nil {
-		log.Error(err.Error())
-		return nil, err
+		log.Errorf("add ttf font error: %v", err)
+		return nil, errors.Wrap(err, "add ttf font")
 	}
 
 	err = pdf.SetFont(cfg.Font.Family, "", cfg.Font.Size)
 	if err != nil {
-		log.Error(err.Error())
-		return nil, err
+		log.Errorf("set font error: %v", err)
+		return nil, errors.Wrap(err, "set font")
 	}
 
 	return pdf, nil
@@ -233,6 +233,9 @@ func (rep *report) renderPDF(dash grafana.Dashboard) (outputPDF *os.File, err er
 	log.Infof("PDF templates config: %+v\n", cfg)
 
 	pdf, err := rep.NewPDF()
+	if err != nil {
+		return nil, errors.Wrap(err, "new pdf file")
+	}
 	rep.createHomePage(pdf, dash)
 
 	// setting rectangle size for grafana panel type: Graph/Singlestat
@@ -274,5 +277,5 @@ func (rep *report) renderPDF(dash grafana.Dashboard) (outputPDF *os.File, err er
 	// WritePdf(pdfPath string) func in gopdf doesn't return error
 	pdf.WritePdf(rep.pdfPath())
 	outputPDF, err = os.Open(rep.pdfPath())
-	return outputPDF, errors.Trace(err)
+	return outputPDF, errors.Wrap(err, "open pdf file")
 }

--- a/grafana_collector/report/report.go
+++ b/grafana_collector/report/report.go
@@ -103,7 +103,7 @@ func (rep *report) Generate() (pdf io.ReadCloser, err error) {
 	// working stage：fetch panel images
 	err = rep.renderPNGsParallel(dash)
 	if err != nil {
-		return nil, errors.Errorf("rendering PNGs in parralel for dash %+v error: %v", dash, err)
+		return nil, errors.Errorf("rendering PNGs in parallel for dash %+v error: %v. It is recommended to select time range within 6 hours on the Dashboard. Otherwise, the grafana timeout problem might occur.", dash, err)
 	}
 
 	// working stage：render panel images to pdf

--- a/vendor/github.com/pkg/errors/.gitignore
+++ b/vendor/github.com/pkg/errors/.gitignore
@@ -1,0 +1,24 @@
+# Compiled Object files, Static and Dynamic libs (Shared Objects)
+*.o
+*.a
+*.so
+
+# Folders
+_obj
+_test
+
+# Architecture specific extensions/prefixes
+*.[568vq]
+[568vq].out
+
+*.cgo1.go
+*.cgo2.c
+_cgo_defun.c
+_cgo_gotypes.go
+_cgo_export.*
+
+_testmain.go
+
+*.exe
+*.test
+*.prof

--- a/vendor/github.com/pkg/errors/.travis.yml
+++ b/vendor/github.com/pkg/errors/.travis.yml
@@ -1,0 +1,11 @@
+language: go
+go_import_path: github.com/pkg/errors
+go:
+  - 1.4.3
+  - 1.5.4
+  - 1.6.2
+  - 1.7.1
+  - tip
+
+script:
+  - go test -v ./...

--- a/vendor/github.com/pkg/errors/LICENSE
+++ b/vendor/github.com/pkg/errors/LICENSE
@@ -1,0 +1,23 @@
+Copyright (c) 2015, Dave Cheney <dave@cheney.net>
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/pkg/errors/README.md
+++ b/vendor/github.com/pkg/errors/README.md
@@ -1,0 +1,52 @@
+# errors [![Travis-CI](https://travis-ci.org/pkg/errors.svg)](https://travis-ci.org/pkg/errors) [![AppVeyor](https://ci.appveyor.com/api/projects/status/b98mptawhudj53ep/branch/master?svg=true)](https://ci.appveyor.com/project/davecheney/errors/branch/master) [![GoDoc](https://godoc.org/github.com/pkg/errors?status.svg)](http://godoc.org/github.com/pkg/errors) [![Report card](https://goreportcard.com/badge/github.com/pkg/errors)](https://goreportcard.com/report/github.com/pkg/errors)
+
+Package errors provides simple error handling primitives.
+
+`go get github.com/pkg/errors`
+
+The traditional error handling idiom in Go is roughly akin to
+```go
+if err != nil {
+        return err
+}
+```
+which applied recursively up the call stack results in error reports without context or debugging information. The errors package allows programmers to add context to the failure path in their code in a way that does not destroy the original value of the error.
+
+## Adding context to an error
+
+The errors.Wrap function returns a new error that adds context to the original error. For example
+```go
+_, err := ioutil.ReadAll(r)
+if err != nil {
+        return errors.Wrap(err, "read failed")
+}
+```
+## Retrieving the cause of an error
+
+Using `errors.Wrap` constructs a stack of errors, adding context to the preceding error. Depending on the nature of the error it may be necessary to reverse the operation of errors.Wrap to retrieve the original error for inspection. Any error value which implements this interface can be inspected by `errors.Cause`.
+```go
+type causer interface {
+        Cause() error
+}
+```
+`errors.Cause` will recursively retrieve the topmost error which does not implement `causer`, which is assumed to be the original cause. For example:
+```go
+switch err := errors.Cause(err).(type) {
+case *MyError:
+        // handle specifically
+default:
+        // unknown error
+}
+```
+
+[Read the package documentation for more information](https://godoc.org/github.com/pkg/errors).
+
+## Contributing
+
+We welcome pull requests, bug fixes and issue reports. With that said, the bar for adding new symbols to this package is intentionally set high.
+
+Before proposing a change, please discuss your change by raising an issue.
+
+## Licence
+
+BSD-2-Clause

--- a/vendor/github.com/pkg/errors/appveyor.yml
+++ b/vendor/github.com/pkg/errors/appveyor.yml
@@ -1,0 +1,32 @@
+version: build-{build}.{branch}
+
+clone_folder: C:\gopath\src\github.com\pkg\errors
+shallow_clone: true # for startup speed
+
+environment:
+  GOPATH: C:\gopath
+
+platform:
+  - x64
+
+# http://www.appveyor.com/docs/installed-software
+install:
+  # some helpful output for debugging builds
+  - go version
+  - go env
+  # pre-installed MinGW at C:\MinGW is 32bit only
+  # but MSYS2 at C:\msys64 has mingw64
+  - set PATH=C:\msys64\mingw64\bin;%PATH%
+  - gcc --version
+  - g++ --version
+
+build_script:
+  - go install -v ./...
+
+test_script:
+  - set PATH=C:\gopath\bin;%PATH%
+  - go test -v ./...
+
+#artifacts:
+#  - path: '%GOPATH%\bin\*.exe'
+deploy: off

--- a/vendor/github.com/pkg/errors/errors.go
+++ b/vendor/github.com/pkg/errors/errors.go
@@ -1,0 +1,269 @@
+// Package errors provides simple error handling primitives.
+//
+// The traditional error handling idiom in Go is roughly akin to
+//
+//     if err != nil {
+//             return err
+//     }
+//
+// which applied recursively up the call stack results in error reports
+// without context or debugging information. The errors package allows
+// programmers to add context to the failure path in their code in a way
+// that does not destroy the original value of the error.
+//
+// Adding context to an error
+//
+// The errors.Wrap function returns a new error that adds context to the
+// original error by recording a stack trace at the point Wrap is called,
+// and the supplied message. For example
+//
+//     _, err := ioutil.ReadAll(r)
+//     if err != nil {
+//             return errors.Wrap(err, "read failed")
+//     }
+//
+// If additional control is required the errors.WithStack and errors.WithMessage
+// functions destructure errors.Wrap into its component operations of annotating
+// an error with a stack trace and an a message, respectively.
+//
+// Retrieving the cause of an error
+//
+// Using errors.Wrap constructs a stack of errors, adding context to the
+// preceding error. Depending on the nature of the error it may be necessary
+// to reverse the operation of errors.Wrap to retrieve the original error
+// for inspection. Any error value which implements this interface
+//
+//     type causer interface {
+//             Cause() error
+//     }
+//
+// can be inspected by errors.Cause. errors.Cause will recursively retrieve
+// the topmost error which does not implement causer, which is assumed to be
+// the original cause. For example:
+//
+//     switch err := errors.Cause(err).(type) {
+//     case *MyError:
+//             // handle specifically
+//     default:
+//             // unknown error
+//     }
+//
+// causer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// Formatted printing of errors
+//
+// All error values returned from this package implement fmt.Formatter and can
+// be formatted by the fmt package. The following verbs are supported
+//
+//     %s    print the error. If the error has a Cause it will be
+//           printed recursively
+//     %v    see %s
+//     %+v   extended format. Each Frame of the error's StackTrace will
+//           be printed in detail.
+//
+// Retrieving the stack trace of an error or wrapper
+//
+// New, Errorf, Wrap, and Wrapf record a stack trace at the point they are
+// invoked. This information can be retrieved with the following interface.
+//
+//     type stackTracer interface {
+//             StackTrace() errors.StackTrace
+//     }
+//
+// Where errors.StackTrace is defined as
+//
+//     type StackTrace []Frame
+//
+// The Frame type represents a call site in the stack trace. Frame supports
+// the fmt.Formatter interface that can be used for printing information about
+// the stack trace of this error. For example:
+//
+//     if err, ok := err.(stackTracer); ok {
+//             for _, f := range err.StackTrace() {
+//                     fmt.Printf("%+s:%d", f)
+//             }
+//     }
+//
+// stackTracer interface is not exported by this package, but is considered a part
+// of stable public API.
+//
+// See the documentation for Frame.Format for more details.
+package errors
+
+import (
+	"fmt"
+	"io"
+)
+
+// New returns an error with the supplied message.
+// New also records the stack trace at the point it was called.
+func New(message string) error {
+	return &fundamental{
+		msg:   message,
+		stack: callers(),
+	}
+}
+
+// Errorf formats according to a format specifier and returns the string
+// as a value that satisfies error.
+// Errorf also records the stack trace at the point it was called.
+func Errorf(format string, args ...interface{}) error {
+	return &fundamental{
+		msg:   fmt.Sprintf(format, args...),
+		stack: callers(),
+	}
+}
+
+// fundamental is an error that has a message and a stack, but no caller.
+type fundamental struct {
+	msg string
+	*stack
+}
+
+func (f *fundamental) Error() string { return f.msg }
+
+func (f *fundamental) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			io.WriteString(s, f.msg)
+			f.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, f.msg)
+	case 'q':
+		fmt.Fprintf(s, "%q", f.msg)
+	}
+}
+
+// WithStack annotates err with a stack trace at the point WithStack was called.
+// If err is nil, WithStack returns nil.
+func WithStack(err error) error {
+	if err == nil {
+		return nil
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+type withStack struct {
+	error
+	*stack
+}
+
+func (w *withStack) Cause() error { return w.error }
+
+func (w *withStack) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v", w.Cause())
+			w.stack.Format(s, verb)
+			return
+		}
+		fallthrough
+	case 's':
+		io.WriteString(s, w.Error())
+	case 'q':
+		fmt.Fprintf(s, "%q", w.Error())
+	}
+}
+
+// Wrap returns an error annotating err with a stack trace
+// at the point Wrap is called, and the supplied message.
+// If err is nil, Wrap returns nil.
+func Wrap(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   message,
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// Wrapf returns an error annotating err with a stack trace
+// at the point Wrapf is call, and the format specifier.
+// If err is nil, Wrapf returns nil.
+func Wrapf(err error, format string, args ...interface{}) error {
+	if err == nil {
+		return nil
+	}
+	err = &withMessage{
+		cause: err,
+		msg:   fmt.Sprintf(format, args...),
+	}
+	return &withStack{
+		err,
+		callers(),
+	}
+}
+
+// WithMessage annotates err with a new message.
+// If err is nil, WithMessage returns nil.
+func WithMessage(err error, message string) error {
+	if err == nil {
+		return nil
+	}
+	return &withMessage{
+		cause: err,
+		msg:   message,
+	}
+}
+
+type withMessage struct {
+	cause error
+	msg   string
+}
+
+func (w *withMessage) Error() string { return w.msg + ": " + w.cause.Error() }
+func (w *withMessage) Cause() error  { return w.cause }
+
+func (w *withMessage) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		if s.Flag('+') {
+			fmt.Fprintf(s, "%+v\n", w.Cause())
+			io.WriteString(s, w.msg)
+			return
+		}
+		fallthrough
+	case 's', 'q':
+		io.WriteString(s, w.Error())
+	}
+}
+
+// Cause returns the underlying cause of the error, if possible.
+// An error value has a cause if it implements the following
+// interface:
+//
+//     type causer interface {
+//            Cause() error
+//     }
+//
+// If the error does not implement Cause, the original error will
+// be returned. If the error is nil, nil will be returned without further
+// investigation.
+func Cause(err error) error {
+	type causer interface {
+		Cause() error
+	}
+
+	for err != nil {
+		cause, ok := err.(causer)
+		if !ok {
+			break
+		}
+		err = cause.Cause()
+	}
+	return err
+}

--- a/vendor/github.com/pkg/errors/stack.go
+++ b/vendor/github.com/pkg/errors/stack.go
@@ -1,0 +1,178 @@
+package errors
+
+import (
+	"fmt"
+	"io"
+	"path"
+	"runtime"
+	"strings"
+)
+
+// Frame represents a program counter inside a stack frame.
+type Frame uintptr
+
+// pc returns the program counter for this frame;
+// multiple frames may have the same PC value.
+func (f Frame) pc() uintptr { return uintptr(f) - 1 }
+
+// file returns the full path to the file that contains the
+// function for this Frame's pc.
+func (f Frame) file() string {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return "unknown"
+	}
+	file, _ := fn.FileLine(f.pc())
+	return file
+}
+
+// line returns the line number of source code of the
+// function for this Frame's pc.
+func (f Frame) line() int {
+	fn := runtime.FuncForPC(f.pc())
+	if fn == nil {
+		return 0
+	}
+	_, line := fn.FileLine(f.pc())
+	return line
+}
+
+// Format formats the frame according to the fmt.Formatter interface.
+//
+//    %s    source file
+//    %d    source line
+//    %n    function name
+//    %v    equivalent to %s:%d
+//
+// Format accepts flags that alter the printing of some verbs, as follows:
+//
+//    %+s   path of source file relative to the compile time GOPATH
+//    %+v   equivalent to %+s:%d
+func (f Frame) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 's':
+		switch {
+		case s.Flag('+'):
+			pc := f.pc()
+			fn := runtime.FuncForPC(pc)
+			if fn == nil {
+				io.WriteString(s, "unknown")
+			} else {
+				file, _ := fn.FileLine(pc)
+				fmt.Fprintf(s, "%s\n\t%s", fn.Name(), file)
+			}
+		default:
+			io.WriteString(s, path.Base(f.file()))
+		}
+	case 'd':
+		fmt.Fprintf(s, "%d", f.line())
+	case 'n':
+		name := runtime.FuncForPC(f.pc()).Name()
+		io.WriteString(s, funcname(name))
+	case 'v':
+		f.Format(s, 's')
+		io.WriteString(s, ":")
+		f.Format(s, 'd')
+	}
+}
+
+// StackTrace is stack of Frames from innermost (newest) to outermost (oldest).
+type StackTrace []Frame
+
+func (st StackTrace) Format(s fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case s.Flag('+'):
+			for _, f := range st {
+				fmt.Fprintf(s, "\n%+v", f)
+			}
+		case s.Flag('#'):
+			fmt.Fprintf(s, "%#v", []Frame(st))
+		default:
+			fmt.Fprintf(s, "%v", []Frame(st))
+		}
+	case 's':
+		fmt.Fprintf(s, "%s", []Frame(st))
+	}
+}
+
+// stack represents a stack of program counters.
+type stack []uintptr
+
+func (s *stack) Format(st fmt.State, verb rune) {
+	switch verb {
+	case 'v':
+		switch {
+		case st.Flag('+'):
+			for _, pc := range *s {
+				f := Frame(pc)
+				fmt.Fprintf(st, "\n%+v", f)
+			}
+		}
+	}
+}
+
+func (s *stack) StackTrace() StackTrace {
+	f := make([]Frame, len(*s))
+	for i := 0; i < len(f); i++ {
+		f[i] = Frame((*s)[i])
+	}
+	return f
+}
+
+func callers() *stack {
+	const depth = 32
+	var pcs [depth]uintptr
+	n := runtime.Callers(3, pcs[:])
+	var st stack = pcs[0:n]
+	return &st
+}
+
+// funcname removes the path prefix component of a function's name reported by func.Name().
+func funcname(name string) string {
+	i := strings.LastIndex(name, "/")
+	name = name[i+1:]
+	i = strings.Index(name, ".")
+	return name[i+1:]
+}
+
+func trimGOPATH(name, file string) string {
+	// Here we want to get the source file path relative to the compile time
+	// GOPATH. As of Go 1.6.x there is no direct way to know the compiled
+	// GOPATH at runtime, but we can infer the number of path segments in the
+	// GOPATH. We note that fn.Name() returns the function name qualified by
+	// the import path, which does not include the GOPATH. Thus we can trim
+	// segments from the beginning of the file path until the number of path
+	// separators remaining is one more than the number of path separators in
+	// the function name. For example, given:
+	//
+	//    GOPATH     /home/user
+	//    file       /home/user/src/pkg/sub/file.go
+	//    fn.Name()  pkg/sub.Type.Method
+	//
+	// We want to produce:
+	//
+	//    pkg/sub/file.go
+	//
+	// From this we can easily see that fn.Name() has one less path separator
+	// than our desired output. We count separators from the end of the file
+	// path until it finds two more than in the function name and then move
+	// one character forward to preserve the initial path segment without a
+	// leading separator.
+	const sep = "/"
+	goal := strings.Count(name, sep) + 2
+	i := len(file)
+	for n := 0; n < goal; n++ {
+		i = strings.LastIndex(file[:i], sep)
+		if i == -1 {
+			// not enough separators found, set i so that the slice expression
+			// below leaves file unmodified
+			i = -len(sep)
+			break
+		}
+	}
+	// get back to 0 or trim the leading separator
+	file = file[i+len(sep):]
+	return file
+}


### PR DESCRIPTION
We need panel id to render its png image file, and then combine all images to generate pdf file. we request  grafana dashboard API (example: http://grafana_IP:3000/api/dashboards/db/:slug, docs: http://docs.grafana.org/v4.6/http_api/dashboard/) to obtain all static rows and its panel ids.
But the dashboard API doesn't contain dynamic rows. 
So we need to implement "Repeating Rows" logic of grafana (http://docs.grafana.org/v4.6/reference/templating/), and gererate repeating rows and its panels.

reference:
gererate panel id logic:
https://github.com/grafana/grafana/blob/v4.6.3/public/app/features/dashboard/model.ts#L159
